### PR TITLE
Fix for security issue with qa-ldap-login

### DIFF
--- a/ActiveDirectoryLDAPServer.php
+++ b/ActiveDirectoryLDAPServer.php
@@ -60,9 +60,9 @@ class ActiveDirectoryLDAPServer extends LDAPServer {
     $read = ldap_read($this->con, $this->dn, $filter, $attributes);
     $data = ldap_get_entries($this->con, $read);
 
-    $fname = $data[0][$fname_tag][0];
-    $sname = $data[0][$sname_tag][0];
-    $mail  = $data[0][$mail_tag][0];
+    $fname = $data[0][strtolower($fname_tag)][0];
+    $sname = $data[0][strtolower($sname_tag)][0];
+    $mail  = $data[0][strtolower($mail_tag)][0];
 
     return array( $fname, $sname, $mail, $this->authenticatedUser);
   }

--- a/ActiveDirectoryLDAPServer.php
+++ b/ActiveDirectoryLDAPServer.php
@@ -1,17 +1,15 @@
 <?php
-/* This class represents behavior and properties 
+/* This class represents behavior and properties
 /* for a Active Directory server with LDAP interfacing enabled.
 /* Tested against a Windows 2008R2 domain AD master.
  */
- 
+
 class ActiveDirectoryLDAPServer extends LDAPServer {
-  // This LDAP attribute represents the legacy logon name in a Windows AD environment
-  private $authenticationAttribute = "sAMAccountName";
   private $dn;
   private $authenticatedUser;
 
   public function bindToLDAP($user,$pass) {
-    $filter = "(".$this->authenticationAttribute."=".$user.")";  
+    $filter = "(".qa_opt('ldap_authentication_attribute')."=".$user.")";
 
     // Check if it authenticates the service account
     error_reporting(E_ALL^ E_WARNING);
@@ -23,12 +21,12 @@ class ActiveDirectoryLDAPServer extends LDAPServer {
 
     if($bind_service_account) {
       $attributes = array('dn');
-      $search = ldap_search($this->con, qa_opt('ldap_login_ad_basedn'), $filter, $attributes);  
+      $search = ldap_search($this->con, qa_opt('ldap_login_ad_basedn'), $filter, $attributes);
       $data = ldap_get_entries($this->con, $search);
     } else {
       return false;
     }
-    
+
     // if the user is found, try to authenticate with his DN and password entered
     if (isset($data[0])) {
       $this->dn = $data[0]['dn'];
@@ -36,13 +34,13 @@ class ActiveDirectoryLDAPServer extends LDAPServer {
     } else {
       return false;
     }
-  
+
     error_reporting(E_ALL);
 
     //we have to preserve the username entered if auth was succesfull
     if($bind_user) {
       $this->authenticatedUser=$user;
-      return($bind_user); 
+      return($bind_user);
     }
 
     return false;
@@ -52,11 +50,11 @@ class ActiveDirectoryLDAPServer extends LDAPServer {
     $fname_tag = qa_opt('ldap_login_fname');
     $sname_tag = qa_opt('ldap_login_sname');
     $mail_tag = qa_opt('ldap_login_mail');
-    
+
     $filter = qa_opt('ldap_login_filter');
     $attributes = array('dn', $fname_tag, $sname_tag, $mail_tag);
 
-    // The DN is known so just use it to read attributes  
+    // The DN is known so just use it to read attributes
     $read = ldap_read($this->con, $this->dn, $filter, $attributes);
     $data = ldap_get_entries($this->con, $read);
 

--- a/GenericLDAPServer.php
+++ b/GenericLDAPServer.php
@@ -42,9 +42,9 @@ class GenericLDAPServer extends LDAPServer {
     $search = ldap_search($this->con, $this->dn, $filter, $attributes);
     $data = ldap_get_entries($this->con, $search);
 
-    $fname = $data[0][$fname_tag][0];
-    $sname = $data[0][$sname_tag][0];
-    $mail  = $data[0][$mail_tag][0];
+    $fname = $data[0][strtolower($fname_tag)][0];
+    $sname = $data[0][strtolower($sname_tag)][0];
+    $mail  = $data[0][strtolower($mail_tag)][0];
 
     return array( $fname, $sname, $mail, $this->authenticatedUser);
   }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To install the plugin:
 
 1. Add the qa-ldap-login directory with plugin files to the qa-plugin directory for your Q2A install.
 
-2. Insert the following line of code above the if statement near line 59 of qa-include/qa-page-login.php
+2. Insert the following line of code above the if statement at line 61 of qa-include/pages/login.php
 
 	require_once QA_INCLUDE_DIR.'../qa-plugin/qa-ldap-login/qa-ldap-process.php';
 

--- a/ldap-login-admin-form.php
+++ b/ldap-login-admin-form.php
@@ -140,7 +140,7 @@ class ldap_login_admin_form {
 
         array(
           'id' => 'ldap_login_ad_pwd_display',
-          'label' => 'Password for AD binging accout',
+          'label' => 'Password for AD binding account',
           'type' => 'text',
           'value' => qa_opt('ldap_login_ad_pwd'),
           'tags' => 'name="ldap_login_ad_pwd_field"',

--- a/ldap-login-admin-form.php
+++ b/ldap-login-admin-form.php
@@ -33,6 +33,9 @@ class ldap_login_admin_form {
     if ($option=='ldap_login_generic_search')
       return 'uid=USERNAME,OU=people,DC=company,DC=local/uid=USERNAME,OU=people3,DC=company,DC=local';
 
+    if ($option=='ldap_authentication_attribute')
+      return 'sAMAccountName'; // The legacy logon name in a Windows AD environment
+
     if ($option=='ldap_login_allow_normal')
       return true;
     if ($option=='ldap_login_allow_registration')
@@ -57,6 +60,8 @@ class ldap_login_admin_form {
       qa_opt('ldap_login_ad_pwd', qa_post_text('ldap_login_ad_pwd_field'));
       qa_opt('ldap_login_ad_basedn', qa_post_text('ldap_login_ad_basedn_field'));
       qa_opt('ldap_login_generic_search', qa_post_text('ldap_login_generic_search_field'));
+
+      qa_opt('ldap_authentication_attribute', qa_post_text('ldap_authentication_attribute_field'));
 
       qa_opt('ldap_login_allow_normal', (bool) qa_post_text('ldap_login_allow_normal_field'));
       qa_opt('ldap_login_allow_registration', (bool) qa_post_text('ldap_login_allow_registration_field'));
@@ -155,6 +160,14 @@ class ldap_login_admin_form {
           'type' => 'text',
           'value' => qa_opt('ldap_login_generic_search'),
           'tags' => 'name="ldap_login_generic_search_field"',
+        ),
+
+        array(
+          'id' => 'ldap_authentication_attribute_display',
+          'label' => 'Generic LDAP search authenticate attribute (e.g. sAMAccountName, sn, mail, givenName etc.)',
+          'type' => 'text',
+          'value' => qa_opt('ldap_authentication_attribute'),
+          'tags' => 'name="ldap_authentication_attribute_field"',
         ),
 
 

--- a/ldap-login-admin-form.php
+++ b/ldap-login-admin-form.php
@@ -82,7 +82,7 @@ class ldap_login_admin_form {
 
       'fields' => array(
         array(
-          'label' => 'Hostname for LDAP Server (ldap://x.y.z for non-SSL, ldaps://x.y.x for SSL)',
+          'label' => 'Hostname for LDAP Server (ldap://x.y.z for non-SSL, ldaps://x.y.z for SSL)',
           'type' => 'text',
           'value' => qa_opt('ldap_login_hostname'),
           'tags' => 'name="ldap_login_hostname_field"',

--- a/ldap-login-layer.php
+++ b/ldap-login-layer.php
@@ -8,7 +8,7 @@
         unset($navigation['register']);
       }
 
-      qa_html_theme_base::nav_list($navigation, $navtype);
+      qa_html_theme_base::nav_list($navigation, $navtype, $level);
     } // end function nav_list
   }
 

--- a/ldap-login-logout-page.php
+++ b/ldap-login-logout-page.php
@@ -35,11 +35,12 @@ class ldap_logout_process {
     } else {
       $tourl = false;
     }
-    
+
     if(isset($_COOKIE["qa-login_fname"])) {
       setcookie("qa-login_fname", '1', time()-$expire, '/');
       setcookie("qa-login_lname", '1', time()-$expire, '/');
       setcookie("qa-login_email", '1', time()-$expire, '/');
+      setcookie("qa-login_user", '1', time()-$expire, '/');
     }
     session_destroy();
     if (!$tourl) {

--- a/ldap-login-logout-page.php
+++ b/ldap-login-logout-page.php
@@ -35,13 +35,6 @@ class ldap_logout_process {
     } else {
       $tourl = false;
     }
-
-    if(isset($_COOKIE["qa-login_fname"])) {
-      setcookie("qa-login_fname", '1', time()-$expire, '/');
-      setcookie("qa-login_lname", '1', time()-$expire, '/');
-      setcookie("qa-login_email", '1', time()-$expire, '/');
-      setcookie("qa-login_user", '1', time()-$expire, '/');
-    }
     session_destroy();
     if (!$tourl) {
       qa_redirect('logout');

--- a/ldap-login.php
+++ b/ldap-login.php
@@ -12,7 +12,7 @@ class ldap_login {
     if(!isset($_COOKIE["qa-login_fname"]) && !isset($_SESSION["qa-login_fname"])) {
       return false;
     } else {
-      if(isset($_COOKIE["bdops-login_fname"])) {
+      if(isset($_COOKIE["qa-login_fname"])) {
         $fname = $_COOKIE["qa-login_fname"];
         $lname = $_COOKIE["qa-login_lname"];
         $email = $_COOKIE["qa-login_email"];

--- a/ldap-login.php
+++ b/ldap-login.php
@@ -4,17 +4,10 @@ class ldap_login {
   function load_module($directory, $urltoroot) {
     $this->directory=$directory;
     $this->urltoroot=$urltoroot;
-  } // end function load_module
-
+  }
   function match_source($source) {
     return $source=='ldap';
   }
-
-  /*
-  REMY BLOM REMOVED ALL OTHER FUNCTIONS FROM THIS CLASS
-  Their functionality is already provided by q2a-core...
-  */
-
-} // end class ldap_login
+}
 
 ?>

--- a/ldap-login.php
+++ b/ldap-login.php
@@ -6,47 +6,14 @@ class ldap_login {
     $this->urltoroot=$urltoroot;
   } // end function load_module
 
-  // check_login checks to see if user is already logged in by looking for
-  // a cookie or session variable (dependent on 'remember me' setting
-  function check_login() {
-    if(!isset($_COOKIE["qa-login_fname"]) && !isset($_SESSION["qa-login_fname"])) {
-      return false;
-    } else {
-      if(isset($_COOKIE["qa-login_fname"])) {
-        $fname = $_COOKIE["qa-login_fname"];
-        $lname = $_COOKIE["qa-login_lname"];
-        $email = $_COOKIE["qa-login_email"];
-        $username = $_COOKIE["qa-login_user"];
-      } else {
-        $fname = $_SESSION["qa-login_fname"];
-        $lname = $_SESSION["qa-login_lname"];
-        $email = $_SESSION["qa-login_email"];
-        $username = $_SESSION["qa-login_user"];
-      }
-      $source = 'ldap';
-      $identifier = $email;
-
-      $fields['email'] = $email;
-      $fields['confirmed'] = true;
-      $fields['handle'] = $username;
-      $fields['name'] = $fname . " " . $lname;
-      qa_log_in_external_user($source,$identifier,$fields);
-    }
-  } // end function check_login
-
   function match_source($source) {
     return $source=='ldap';
   }
 
-  function login_html($tourl, $context) {} 
-
-  function logout_html ($tourl) {
-    require_once QA_INCLUDE_DIR."qa-base.php";
-
-    $_SESSION['logout_url'] = $tourl;
-    $logout_url = qa_path('auth/logout', null, qa_path_to_root());
-    echo('<a href="'.$logout_url.'">'.qa_lang_html('main/nav_logout').'</a>');
-  } // end function logout_html
+  /*
+  REMY BLOM REMOVED ALL OTHER FUNCTIONS FROM THIS CLASS
+  Their functionality is already provided by q2a-core...
+  */
 
 } // end class ldap_login
 

--- a/qa-ldap-process.php
+++ b/qa-ldap-process.php
@@ -70,7 +70,7 @@
           exit();
         }
 
-        if($inremember == 'true') {
+        if($inremember == '1') {
           setcookie("qa-login_lname", $lname, time() + $expire, '/');
           setcookie("qa-login_fname", $fname, time() + $expire, '/');
           setcookie("qa-login_email", $email, time() + $expire, '/');

--- a/qa-ldap-process.php
+++ b/qa-ldap-process.php
@@ -69,18 +69,17 @@
           qa_redirect('login');
           exit();
         }
+        // REMY BLOM: DO WHAT THE SCRIPT IS SUPPOSED TO DO, DON'T SET COOKIES?!?!?!
+        // (especially not when they introduce an a possibility to do Cookie-SPOOFING!)
+        $source = 'ldap';
+        $identifier = $email;
 
-        if($inremember == '1') {
-          setcookie("qa-login_lname", $lname, time() + $expire, '/');
-          setcookie("qa-login_fname", $fname, time() + $expire, '/');
-          setcookie("qa-login_email", $email, time() + $expire, '/');
-          setcookie("qa-login_user", $user, time() + $expire, '/');
-        } else {
-          $_SESSION["qa-login_lname"] = $lname;
-          $_SESSION["qa-login_fname"] = $fname;
-          $_SESSION["qa-login_email"] = $email;
-          $_SESSION["qa-login_user"] = $user;
-        }
+        $fields['email'] = $email;
+        $fields['confirmed'] = true;
+        $fields['handle'] = $user;
+        $fields['name'] = $fname . " " . $lname;
+        qa_log_in_external_user($source, $identifier, $fields, $inremember);
+
         $topath=qa_get('to');
         if (isset($topath))
           qa_redirect_raw(qa_path_to_root().$topath); // path already provided as URL fragment

--- a/qa-ldap-process.php
+++ b/qa-ldap-process.php
@@ -69,8 +69,6 @@
           qa_redirect('login');
           exit();
         }
-        // REMY BLOM: DO WHAT THE SCRIPT IS SUPPOSED TO DO, DON'T SET COOKIES?!?!?!
-        // (especially not when they introduce an a possibility to do Cookie-SPOOFING!)
         $source = 'ldap';
         $identifier = $email;
 

--- a/qa-ldap-process.php
+++ b/qa-ldap-process.php
@@ -63,6 +63,13 @@
         $email = $name[2];
         $user = $name[3];
         
+		// Do not login or create account if mail value is NULL
+		if ( '' == $email ){
+		  // FIXME somehow print a message
+          qa_redirect('login');
+          exit();
+		}
+		
         if($inremember == 'true') {
           setcookie("qa-login_lname", $lname, time() + $expire, '/');
           setcookie("qa-login_fname", $fname, time() + $expire, '/');


### PR DESCRIPTION
I recently discoved a security issue with qa-ldap-plugin. It is very easy to login as any ldap-user known to q2a without knowing the user's password simply by manually creating the right cookies in the browser. Especially when an attacker is familiar with the ldap being used, like in our case, where the uid is simply firstname.lastname, it is extremely easy to gain access to an account using cookie-spoofing.

This Pull Request fixes the issue. Please merge it into your forked version of qa-ldap-login so it is no longer vulnerable.

Best regards,

Remy Blom
The Netherlands